### PR TITLE
Add IPv6 support

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -24,7 +24,7 @@ from multiping import multi_ping
 
 if __name__ == "__main__":
 
-    addrs = ["8.8.8.8", "cnn.com", "127.0.0.1", "youtube.com"]
+    addrs = ["8.8.8.8", "cnn.com", "127.0.0.1", "youtube.com", "2001:4860:4860::8888"]
 
     print("sending one round of pings and checking twice for responses")
     mp = MultiPing(addrs)

--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -34,6 +34,7 @@ _ICMP_HDR_PACK_FORMAT = "!BBHHH"
 _ICMP_HDR_OFFSET = 20
 _ICMP_ID_OFFSET = _ICMP_HDR_OFFSET + 4
 _ICMP_PAYLOAD_OFFSET = _ICMP_HDR_OFFSET + 8
+_ICMP_REPLY = 0
 
 _IPV6_TYPE_OFFSET = 0
 _ICMPV6_REQUEST = 128
@@ -345,7 +346,7 @@ class MultiPing(object):
 
                         self._remaining_ids.remove(pkt_id)
 
-                elif pkt[_IPV6_TYPE_OFFSET] != _ICMPV6_REQUEST:
+                elif pkt[_ICMP_HDR_OFFSET] == _ICMP_REPLY:
 
                     pkt_id = (pkt[_ICMP_ID_OFFSET] << 8) + \
                         pkt[_ICMP_ID_OFFSET + 1]

--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -145,7 +145,6 @@ class MultiPing(object):
 
         """
         pkt_id = self._last_used_id
-        print "last_used_id ", pkt_id
 
         if ':' in dest_addr:
             icmp_request = 128
@@ -182,9 +181,7 @@ class MultiPing(object):
 
         try:
             socket.inet_pton(socket.AF_INET6, dest_addr)
-            print "sending icmp6", dest_addr
             self._sock6.sendto(full_pkt, full_dest_addr)
-            print "sent icmp6", dest_addr
 
         except:
             self._sock.sendto(full_pkt, full_dest_addr)

--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -336,7 +336,7 @@ class MultiPing(object):
             for pkt, resp_receive_time in pkts:
                 # Extract the ICMP ID of the response
 
-                pkt_id = 0
+                pkt_id = None
                 if pkt[_IPV6_TYPE_OFFSET] == _ICMPV6_ECHO_REPLY:
 
                     pkt_id = (pkt[_ICMPV6_ID_OFFSET] << 8) + \
@@ -349,7 +349,7 @@ class MultiPing(object):
                         pkt[_ICMP_ID_OFFSET + 1]
                     payload = pkt[_ICMP_PAYLOAD_OFFSET:]
 
-                if pkt_id and pkt_id in self._remaining_ids:
+                if pkt_id in self._remaining_ids:
                     # The sending timestamp was encoded in the echo request
                     # body and is now returned to us in the response. Note that
                     # network byte order doesn't matter here, since we get

--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -179,12 +179,16 @@ class MultiPing(object):
         # for that.
         full_dest_addr = (dest_addr, 0)
 
-        try:
-            socket.inet_pton(socket.AF_INET6, dest_addr)
-            self._sock6.sendto(full_pkt, full_dest_addr)
-
-        except:
+        if icmp_request == 8:
             self._sock.sendto(full_pkt, full_dest_addr)
+        else:
+            socket.inet_pton(socket.AF_INET6, dest_addr)
+            try:
+                self._sock6.sendto(full_pkt, full_dest_addr)
+            except:
+                # on systems without IPv6 connectivity, sendto will fail with
+                # 'No route to host'
+                pass
 
     def send(self):
         """


### PR DESCRIPTION
Submitting a possible resolution to Issue #6. Added Google's public IPv6 DNS server address to demo.py:

```
addrs = ["8.8.8.8", "cnn.com", "127.0.0.1", "youtube.com", "2001:4860:4860::8888"]
```

 When running on a host with IPv6 connectivity: the result should be this:

```
$ sudo python demo.py
Password:
sending one round of pings and checking twice for responses
   received responses:  ['127.0.0.1']
   no responses so far: ['8.8.8.8', '2a04:4e42:600::323', '2a00:1450:400a:805::200e', '2001:4860:4860::8888']
   --- trying another receive ---
   received responses:  ['2a04:4e42:600::323', '2001:4860:4860::8888', '8.8.8.8', '2a00:1450:400a:805::200e']
   still no responses:  []

sending again, but waiting with retries if no response received
    received responses:     ['2001:4860:4860::8888', '2a00:1450:400a:805::200e', '127.0.0.1', '8.8.8.8']
    1. retry, resending to: ['2a04:4e42:600::323']
    received responses:     ['2a04:4e42:600::323']
    all done, received responses from everyone

sending again, waiting with retries via provided send_receive()
    reponses: ['2a04:4e42:600::323', '2001:4860:4860::8888', '127.0.0.1', '2a00:1450:400a:805::200e', '8.8.8.8']
```

On a host without IPv6 connectivity, the result is the following:

```
$ sudo python demo.py
sending one round of pings and checking twice for responses
   received responses:  ['127.0.0.1']
   no responses so far: ['8.8.8.8', '151.101.129.67', '216.58.192.14', '2001:4860:4860::8888']
   --- trying another receive ---
   received responses:  ['8.8.8.8']
   still no responses:  ['151.101.129.67', '216.58.192.14', '2001:4860:4860::8888']

sending again, but waiting with retries if no response received
    received responses:     ['127.0.0.1']
    1. retry, resending to: ['8.8.8.8', '151.101.129.67', '216.58.192.14', '2001:4860:4860::8888']
    received responses:     []
    2. retry, resending to: ['8.8.8.8', '151.101.129.67', '216.58.192.14', '2001:4860:4860::8888']
    received responses:     ['8.8.8.8', '151.101.129.67']
    3. retry, resending to: ['216.58.192.14', '2001:4860:4860::8888']
    no response received in time, even after 3 retries: ['216.58.192.14', '2001:4860:4860::8888']

sending again, waiting with retries via provided send_receive()
    reponses: ['216.58.192.14', '8.8.8.8', '127.0.0.1', '151.101.129.67']
    no response received in time, even after retries: ['2001:4860:4860::8888']
```

As excepted, the IPv4 addresses will be used and the IPv6 address is reported as unreachable.

Please review and provide feedback. Happy to incorporate any suggestions.

