### PR TITLE
Error removed

### DIFF
--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -393,9 +393,6 @@ class MultiPing(object):
             # send().
             self._remaining_ids = list(self._id_to_addr.keys())
 
-        if len(self._remaining_ids) == 0:
-            raise MultiPingError("No responses pending")
-
         remaining_time = timeout
         results        = {}
 


### PR DESCRIPTION
"no responses pending" should not be handled as an error. If someone uses multi_ping with retry != 0, he/she does it to make sure that a possibly sent ICMP packages does not get lost. But when the first trial worked, the function should only exit and not throw by any means an error.