### PR TITLE
Fix failure while running on systems without IPv6 support

### DIFF
--- a/multiping/__init__.py
+++ b/multiping/__init__.py
@@ -160,12 +160,25 @@ class MultiPing(object):
         if sock:
             self._sock = sock
         else:
-            self._sock = self._open_icmp_socket(socket.AF_INET)
-            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 131072)
+            self._open_ipv4_icmp_socket()
+            self._open_ipv6_icmp_socket()
+
+    def _open_ipv4_icmp_socket(self):
+        self._sock = self._open_icmp_socket(socket.AF_INET)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 131072)
+
+    def _open_ipv6_icmp_socket(self, ignore_failures=True):
+        try:
             self._sock6 = self._open_icmp_socket(socket.AF_INET6)
             self._sock6.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 131072)
+        except socket.error:
+            if ignore_failures:
+                return
+            else:
+                raise MultiPingSocketError("IPv6 address family not supported")
 
-    def _open_icmp_socket(self, family):
+    @staticmethod
+    def _open_icmp_socket(family):
         """
         Opens a socket suitable for sending/receiving ICMP echo
         requests/responses.


### PR DESCRIPTION
For now, an attempt of creating of IPv6 socket on e.g. Linux kernels
with IPv6 support disabled will result the error:
```
    socket.error: [Errno 97] Address family not supported by protocol
```

This patch wraps the creation of an ICMP socket for IPv6 to prevent failure
on such systems.